### PR TITLE
ECRにPushできない問題の解消

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-1
+          aws-region: us-east-1
       - uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: "true"
@@ -47,7 +47,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-1
+          aws-region: us-east-1
       - uses: actions/checkout@v3
       - uses: aws-actions/amazon-ecr-login@v1
         with:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -19,6 +19,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
       - uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: "true"
+          registry-type: public
         id: login-ecr
       - uses: actions/checkout@v3
       - name: build and push docker image to ecr
@@ -45,6 +48,9 @@ jobs:
           aws-region: ap-northeast-1
       - uses: actions/checkout@v3
       - uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: "true"
+          registry-type: public
         id: login-ecr
       - name: build and push docker image to ecr
         id: build-image

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -3,8 +3,6 @@ name: Push Image CI
 on:
   push:
     branches: ["master"]
-  pull_request:
-    branches: ["master"]
 
 jobs:
   pack_backend:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -3,6 +3,8 @@ name: Push Image CI
 on:
   push:
     branches: ["master"]
+  pull_request:
+    branches: ["master"]
 
 jobs:
   pack_backend:


### PR DESCRIPTION
https://github.com/aws-actions/amazon-ecr-login#login-to-amazon-ecr-public-then-build-and-push-a-docker-image

上記の使い方から、registry-typeを明示的にPublicにする必要があると判断し追加した。